### PR TITLE
Fix/Handle execution for no initial/entry step

### DIFF
--- a/go-steps.go
+++ b/go-steps.go
@@ -45,6 +45,11 @@ func (steps Steps) Execute(initArgs ...any) ([]interface{}, error) {
 	var stepOutput []interface{}
 	var stepError error
 
+	// no entry or initial step
+	if len(steps) == 0 {
+		return nil, nil
+	}
+
 	// entry step
 	var isEntryStep bool = true
 	step := steps[0]


### PR DESCRIPTION
In `v0.1-beta` if there are no steps (no initial or subsequent steps) then the `Execute()` functions panics and exits

<img width="934" alt="image" src="https://github.com/TanmoySG/go-steps/assets/36238254/1cfd85e8-2bf5-4995-b8f2-ab34f9c2f81a">

To Fix this adding a simple check to see if (initial) steps are not empty. If it is then no error is returned or no panics are caused.

```go 
	// no entry or initial step
	if len(steps) == 0 {
		return nil, nil
	}
```

