### PR TITLE
[bug fix] Step retries for max retry even if step state is not error

### DIFF
--- a/go_steps.go
+++ b/go_steps.go
@@ -139,7 +139,7 @@ func (step *Step) shouldRetry() bool {
 		return true
 	}
 
-	if step.StepOpts.RetryAllErrors {
+	if step.stepResult.StepState == StepStateError && step.StepOpts.RetryAllErrors {
 		return true
 	}
 
@@ -161,14 +161,10 @@ func (step *Step) shouldExit() bool {
 		return false
 	}
 
-	if step.StepOpts.MaxRunAttempts == step.stepRunProgress.runCount {
-		switch step.stepResult.StepState {
-		case StepStateComplete, StepStateSkipped:
-			return false
-		default: // StepStateError, StepStatePending, StepStateFailed
-			return true
-		}
+	switch step.stepResult.StepState {
+	case StepStateComplete, StepStateSkipped:
+		return false
+	default: // StepStateError, StepStatePending, StepStateFailed
+		return true
 	}
-
-	return false
 }

--- a/go_steps_test.go
+++ b/go_steps_test.go
@@ -141,42 +141,24 @@ func Test_shouldExit(t *testing.T) {
 	}{
 		{
 			Step: Step{
-				StepOpts: StepOpts{
-					MaxRunAttempts: 2,
-				},
 				stepResult: &StepResult{
 					StepState: StepStateError,
 				},
-				stepRunProgress: StepRunProgress{
-					runCount: 2,
-				},
 			},
 			ExpectedShouldExit: true,
 		},
 		{
 			Step: Step{
-				StepOpts: StepOpts{
-					MaxRunAttempts: 2,
-				},
 				stepResult: &StepResult{
 					StepState: StepStateComplete,
 				},
-				stepRunProgress: StepRunProgress{
-					runCount: 2,
-				},
 			},
 			ExpectedShouldExit: false,
 		},
 		{
 			Step: Step{
-				StepOpts: StepOpts{
-					MaxRunAttempts: 2,
-				},
 				stepResult: &StepResult{
 					StepState: StepStateSkipped,
-				},
-				stepRunProgress: StepRunProgress{
-					runCount: 2,
 				},
 			},
 			ExpectedShouldExit: false,
@@ -194,26 +176,6 @@ func Test_shouldExit(t *testing.T) {
 				},
 			},
 			ExpectedShouldExit: true,
-		},
-		{
-			Step: Step{
-				StepOpts: StepOpts{
-					MaxRunAttempts: 2,
-				},
-			},
-		},
-		{
-			Step: Step{
-				StepOpts: StepOpts{
-					MaxRunAttempts: 2,
-				},
-				stepRunProgress: StepRunProgress{
-					runCount: 1,
-				},
-				stepResult: &StepResult{
-					StepState: StepStatePending,
-				},
-			},
 		},
 	}
 


### PR DESCRIPTION
A step would retry for all errors for MaxRunAttempts even when step moved out of Error State.

Cause
- `shouldRetry` returns true if `step.StepOpts.RetryAllErrors` is set to true, without checking if `step.stepResult.StepState` is in Error state. 

```go
	if step.StepOpts.RetryAllErrors {
		return true
	}
```

Fix
- Adding check for `step.stepResult.StepState` to be StepStateError in addition to the RetryAllErrors fixes this bug.

```go
	if step.stepResult.StepState == StepStateError && step.StepOpts.RetryAllErrors {
		return true
	}
```

In addition `step.StepOpts.MaxRunAttempts == step.stepRunProgress.runCount` has been removed from `shouldExit`

---

This pull request includes changes to the `go_steps.go` file to enhance the retry and exit logic for steps. The most important changes include adding a condition to check the step state before retrying and refactoring the exit logic to use a switch statement.

Enhancements to retry logic:

* [`go_steps.go`](diffhunk://#diff-a5a78453a1badcbe504c57ba6f0424187000af74951102aaed4db10ca316a1d0L142-R142): Updated the `shouldRetry` method to include a condition that checks if the step state is `StepStateError` before retrying.

Refactoring exit logic:

* [`go_steps.go`](diffhunk://#diff-a5a78453a1badcbe504c57ba6f0424187000af74951102aaed4db10ca316a1d0L164-L174): Refactored the `shouldExit` method to use a switch statement for better readability and removed the redundant return statement.